### PR TITLE
Leave repository in clean state after commit

### DIFF
--- a/post-commit
+++ b/post-commit
@@ -38,3 +38,5 @@ for fn in "${ADDED_FILES[@]}"; do
   # Uncomment sed command to replace multiple empty lines with a single empty line
   # sed '/^$/N;/^\n$/D' "$fn" # GNU sed compatible only
 done
+
+git add "${ADDED_FILES[@]}" && git commit --amend --reuse-message


### PR DESCRIPTION
This will clean repository state after commit removing all `@commit` from diff.